### PR TITLE
Change doclet's tag alias format

### DIFF
--- a/__tests__/documentationGeneration.test.js
+++ b/__tests__/documentationGeneration.test.js
@@ -14,7 +14,7 @@ describe('documentation generation', () => {
   })
 
   it('documentation for Counter should not be generated', (done) => {
-    const filename = path.join(docsOutputPath, 'module-(Vue)%20Counter.html')
+    const filename = path.join(docsOutputPath, 'Vue_Counter.html')
 
     fs.stat(filename, (err, stats) => {
       expect(err).not.toBeNull()
@@ -25,7 +25,7 @@ describe('documentation generation', () => {
   })
 
   describe('BetterCounter documentation generation', () => {
-    const filename = path.join(docsOutputPath, 'module-(Vue)%20BetterCounter.html')
+    const filename = path.join(docsOutputPath, 'Vue_BetterCounter.html')
 
     it('documentation should be generated', (done) => {
       fs.stat(filename, (err, stats) => {

--- a/__tests__/vueTag.test.js
+++ b/__tests__/vueTag.test.js
@@ -21,7 +21,7 @@ describe('vueTag', () => {
       },
       scope: 'vue',
       kind: 'module',
-      alias: '(Vue) foo.bar'
+      alias: 'Vue:foo.bar'
     })
   })
 })

--- a/lib/vueTag.js
+++ b/lib/vueTag.js
@@ -7,6 +7,6 @@ exports.options = {
 
     doclet.scope = 'vue'
     doclet.kind = 'module'
-    doclet.alias = '(Vue) ' + componentName
+    doclet.alias = 'Vue:' + componentName
   }
 }


### PR DESCRIPTION
Related to #5. 

I know I spoke about `doclet.alias = componentName + '.vue'`, but it was not working as expected: the module name was `vue` and not `componentName.vue`.

![capture d ecran de 2017-11-19 08-48-52](https://user-images.githubusercontent.com/2103975/32988512-7f8a1cd6-cd06-11e7-8f40-f104e288e986.png)

Now, we got something like that : 
![capture d ecran de 2017-11-19 08-50-07](https://user-images.githubusercontent.com/2103975/32988537-af4ab412-cd06-11e7-8366-7bbbabbe8067.png)

  