### PR TITLE
feat: Custom module names

### DIFF
--- a/cypress/integration/renderers/default.spec.js
+++ b/cypress/integration/renderers/default.spec.js
@@ -5,6 +5,16 @@ describe('Renderers: default', () => {
     cy.visit('/../../../example/docs/module-better-components_BetterCounter.html');
   });
 
+  it('should renders module name correctly', () => {
+    cy
+      .get('.page-title')
+      .contains('Module: better-components/BetterCounter');
+
+    cy
+      .get('nav a[href="module-better-components_BetterCounter.html"]')
+      .contains('better-components/BetterCounter');
+  });
+
   it('should renders props correctly', () => {
     const props = [
       {

--- a/cypress/integration/renderers/default.spec.js
+++ b/cypress/integration/renderers/default.spec.js
@@ -2,7 +2,7 @@
 
 describe('Renderers: default', () => {
   before(() => {
-    cy.visit('/../../../example/docs/BetterCounter.html');
+    cy.visit('/../../../example/docs/module-better-components_BetterCounter.html');
   });
 
   it('should renders props correctly', () => {
@@ -134,13 +134,13 @@ describe('Renderers: default', () => {
       .contains('decrement()')
       .next('.description')
       .next('.details')
-      .find('a[href="BetterCounter.vue.html#line51"]', 'line 51');
+      .contains('a[href="better-components_BetterCounter.vue.html#line52"]', 'line 52');
 
     cy.get('#increment')
       .contains('increment()')
       .next('.description')
       .next('.details')
-      .find('a[href="BetterCounter.vue.html#line44"]', 'line 44');
+      .contains('a[href="better-components_BetterCounter.vue.html#line45"]', 'line 45');
 
     cy.get('#showDialog')
       .contains('showDialog(counter)')
@@ -148,7 +148,7 @@ describe('Renderers: default', () => {
       .next('h5')
       .next('.params')
       .next('.details')
-      .find('a[href="BetterCounter.vue.html#line59"]', 'line 59');
+      .contains('a[href="better-components_BetterCounter.vue.html#line60"]', 'line 60');
 
     cy.contains('created()').should('not.exist');
   });

--- a/cypress/integration/renderers/docstrap.spec.js
+++ b/cypress/integration/renderers/docstrap.spec.js
@@ -2,7 +2,7 @@
 
 describe('Renderers: docstrap', () => {
   before(() => {
-    cy.visit('/../../../example/docs-docstrap/BetterCounter.html');
+    cy.visit('/../../../example/docs-docstrap//module-better-components_BetterCounter.html');
   });
 
   it('should renders props correctly', () => {
@@ -134,21 +134,21 @@ describe('Renderers: docstrap', () => {
       .parent()
       .next('dd')
       .find('.details')
-      .find('a[href="BetterCounter.vue.html#sunlight-1-line-51"]', 'line 51');
+      .contains('a[href="better-components_BetterCounter.vue.html#sunlight-1-line-52"]', 'line 52');
 
     cy.get('#increment')
       .contains('increment()')
       .parent()
       .next('dd')
       .find('.details')
-      .find('a[href="BetterCounter.vue.html#sunlight-1-line-44"]', 'line 44');
+      .contains('a[href="better-components_BetterCounter.vue.html#sunlight-1-line-45"]', 'line 45');
 
     cy.get('#showDialog')
       .contains('showDialog(counter)')
       .parent()
       .next('dd')
       .find('.details')
-      .find('a[href="BetterCounter.vue.html#sunlight-1-line-59"]', 'line 59');
+      .contains('a[href="better-components_BetterCounter.vue.html#sunlight-1-line-60"]', 'line 60');
 
     cy.contains('created()').should('not.exist');
   });

--- a/cypress/integration/renderers/docstrap.spec.js
+++ b/cypress/integration/renderers/docstrap.spec.js
@@ -5,6 +5,16 @@ describe('Renderers: docstrap', () => {
     cy.visit('/../../../example/docs-docstrap//module-better-components_BetterCounter.html');
   });
 
+  it('should renders module name correctly', () => {
+    cy
+      .get('.page-title')
+      .contains('Module: better-components/BetterCounter');
+
+    cy
+      .get('.nav .dropdown a[href="module-better-components_BetterCounter.html"]')
+      .contains('better-components/BetterCounter');
+  });
+
   it('should renders props correctly', () => {
     const props = [
       {

--- a/cypress/integration/renderers/minami.spec.js
+++ b/cypress/integration/renderers/minami.spec.js
@@ -5,6 +5,16 @@ describe('Renderers: minami', () => {
     cy.visit('/../../../example/docs-minami/module-better-components_BetterCounter.html');
   });
 
+  it('should renders module name correctly', () => {
+    cy
+      .get('.page-title')
+      .contains('better-components/BetterCounter');
+
+    cy
+      .get('.nav-item-name a[href="module-better-components_BetterCounter.html"]')
+      .contains('better-components/BetterCounter');
+  });
+
   it('should renders props correctly', () => {
     const props = [
       {

--- a/cypress/integration/renderers/minami.spec.js
+++ b/cypress/integration/renderers/minami.spec.js
@@ -2,7 +2,7 @@
 
 describe('Renderers: minami', () => {
   before(() => {
-    cy.visit('/../../../example/docs-minami/BetterCounter.html');
+    cy.visit('/../../../example/docs-minami/module-better-components_BetterCounter.html');
   });
 
   it('should renders props correctly', () => {
@@ -135,19 +135,19 @@ describe('Renderers: minami', () => {
       .contains('decrement()')
       .next('.description')
       .next('.details')
-      .contains('a[href="BetterCounter.vue.html#line51"]', 'line 51');
+      .contains('a[href="better-components_BetterCounter.vue.html#line52"]', 'line 52');
 
     cy.get('#increment')
       .contains('increment()')
       .next('.description')
       .next('.details')
-      .contains('a[href="BetterCounter.vue.html#line44"]', 'line 44');
+      .contains('a[href="better-components_BetterCounter.vue.html#line45"]', 'line 45');
 
     cy.get('#showDialog')
       .contains('showDialog(counter)')
       .next('.description')
       .next('.details')
-      .contains('a[href="BetterCounter.vue.html#line59"]', 'line 59');
+      .contains('a[href="better-components_BetterCounter.vue.html#line60"]', 'line 60');
 
     cy.contains('created()').should('not.exist');
   });

--- a/cypress/integration/renderers/tui.spec.js
+++ b/cypress/integration/renderers/tui.spec.js
@@ -2,7 +2,7 @@
 
 describe('Renderers: tui', () => {
   before(() => {
-    cy.visit('/../../../example/docs-tui/BetterCounter.html');
+    cy.visit('/../../../example/docs-tui/module-better-components_BetterCounter.html');
   });
 
   it('should renders props correctly', () => {
@@ -131,15 +131,15 @@ describe('Renderers: tui', () => {
     cy.contains('h3', 'Methods').should('have.attr', 'class', 'subsection-title');
     cy.get('#decrement')
       .contains('decrement()')
-      .contains('a[href="BetterCounter.vue.html#line51"]', 'line 51');
+      .contains('a[href="better-components_BetterCounter.vue.html#line52"]', 'line 52');
 
     cy.get('#increment')
       .contains('increment()')
-      .contains('a[href="BetterCounter.vue.html#line44"]', 'line 44');
+      .contains('a[href="better-components_BetterCounter.vue.html#line45"]', 'line 45');
 
     cy.get('#showDialog')
       .contains('showDialog(counter)')
-      .contains('a[href="BetterCounter.vue.html#line59"]', 'line 59');
+      .contains('a[href="better-components_BetterCounter.vue.html#line60"]', 'line 60');
 
     cy.contains('created()').should('not.exist');
   });

--- a/cypress/integration/renderers/tui.spec.js
+++ b/cypress/integration/renderers/tui.spec.js
@@ -5,6 +5,20 @@ describe('Renderers: tui', () => {
     cy.visit('/../../../example/docs-tui/module-better-components_BetterCounter.html');
   });
 
+  it('should renders module name correctly', () => {
+    cy
+      .get('.title')
+      .contains('Module: better-components/BetterCounter');
+
+    cy
+      .get('h2')
+      .contains('better-components/BetterCounter');
+
+    cy
+      .get('nav.lnb .lnb-api li a[href="module-better-components_BetterCounter.html"]')
+      .contains('better-components/BetterCounter');
+  });
+
   it('should renders props correctly', () => {
     const props = [
       {

--- a/example/jsdoc.js
+++ b/example/jsdoc.js
@@ -6,6 +6,7 @@ module.exports = {
   source: {
     include: [
       'src/',
+      'src/better-components',
       'README.md',
     ],
     includePattern: '\\.(vue|js)$',

--- a/example/src/Counter.vue
+++ b/example/src/Counter.vue
@@ -1,0 +1,33 @@
+<template>
+  <div>
+    {{ counter }}
+  </div>
+</template>
+
+<script>
+/**
+ * @vue-data {Number} [counter=0] Counter value
+ */
+export default {
+  name: 'Counter',
+  data() {
+    return {
+      counter: 0,
+    };
+  },
+  mounted() {
+    this.interval = setInterval(() => this.increment(), 1000);
+  },
+  beforeDestroy() {
+    clearInterval(this.interval);
+  },
+  methods: {
+    /**
+     * Increment the internal counter.
+     */
+    increment() {
+      this.counter += 1;
+    }
+  }
+};
+</script>

--- a/example/src/better-components/BetterCounter.vue
+++ b/example/src/better-components/BetterCounter.vue
@@ -11,6 +11,7 @@
   import { mapState } from 'vuex';
 
   /**
+   * @module better-components/BetterCounter
    * @vue-prop {Number} initialCounter
    * @vue-prop {Number} [step=1] Step
    * @vue-data {Number} counter - Current counter's value

--- a/index.js
+++ b/index.js
@@ -24,6 +24,10 @@ exports.handlers = {
 
       // The main doclet before `export default {}`
       if (e.doclet.longname === 'module.exports') {
+        e.doclet.kind = 'module';
+        e.doclet.name = componentName;
+        e.doclet.alias = componentName;
+        e.doclet.longname = `module:${componentName}`;
         mainDocletLines[fullPath] = e.doclet.meta.lineno;
       }
 
@@ -35,10 +39,6 @@ exports.handlers = {
         const data = e.doclet._vueData || [];
         const computed = e.doclet._vueComputed || [];
 
-        e.doclet.kind = 'module';
-        e.doclet.name = componentName;
-        e.doclet.alias = componentName;
-        e.doclet.longname = componentName;
         e.doclet.description = render(renderer, e.doclet.description || '', props, data, computed);
 
         // Remove meta for not rendering source for this doclet

--- a/index.js
+++ b/index.js
@@ -28,6 +28,12 @@ exports.handlers = {
         e.doclet.name = componentName;
         e.doclet.alias = componentName;
         e.doclet.longname = `module:${componentName}`;
+      }
+
+      if (
+        !/[.~#]/.test(e.doclet.longname) // filter component's properties and member, not the best way but it werks
+        && e.doclet.longname.startsWith('module:')
+      ) {
         mainDocletLines[fullPath] = e.doclet.meta.lineno;
       }
 


### PR DESCRIPTION
When using this on `BetterCounter.vue`:
```js
/**
 * @module better-components/BetterCounter
 * ...
 */
```

![capture d ecran de 2018-07-03 21-43-55](https://user-images.githubusercontent.com/2103975/42241256-37bb9112-7f0a-11e8-91e6-1ae1b5d4c56c.png)

Other components without manually defined module name are not altered with this feature.

It close #83 
