### PR TITLE
fix(pkg): file "config.js" should be packaged too

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A JSDoc plugin for documenting .vue files.",
   "main": "index.js",
   "files": [
-    "lib"
+    "lib",
+    "config.js"
   ],
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Close #124, incriminated commit: 5a4edba51d227f7aa5b0e7b0d2fc4888ba76c32e

We actually need to package `config.js` file too prevent error:

```
> jsdoc -c jsdoc.config.json

internal/modules/cjs/loader.js:550
    throw err;
    ^

Error: Cannot find module './config'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:548:15)
    at Requizzle.requizzle (/Users/paul/dev/kpmg/SOFY2/frontend/node_modules/requizzle/lib/requizzle.js:87:22)
    at infectProxy (/Users/paul/dev/kpmg/SOFY2/frontend/node_modules/requizzle/lib/loader.js:82:28)
    at Module.targetModule.require (/Users/paul/dev/kpmg/SOFY2/frontend/node_modules/requizzle/lib/loader.js:101:11)
    at require (internal/modules/cjs/helpers.js:11:18)
.....
```