### PR TITLE
fix(parser): JavaScript files are not all interpreted as a Vue component anymore

### DIFF
--- a/cypress/integration/templates/default.spec.js
+++ b/cypress/integration/templates/default.spec.js
@@ -71,7 +71,7 @@ describe('Template: default', () => {
         name: '<code>counter</code>',
         type: 'Number',
         defaultValue: '-',
-        description: "Current counter's value",
+        description: 'Current counter\'s value',
       },
     ];
 
@@ -237,7 +237,7 @@ describe('Template JS: default', () => {
         name: '<code>counter</code>',
         type: 'Number',
         defaultValue: '-',
-        description: "Current counter's value",
+        description: 'Current counter\'s value',
       },
     ];
 
@@ -328,5 +328,32 @@ describe('Template JS: default', () => {
       .contains('a[href="js_CounterJS.js.html#line51"]', 'line 51');
 
     cy.contains('created()').should('not.exist');
+  });
+});
+
+describe('JS files rendered or not as Vue Component', () => {
+  before(() => {
+    cy.visit('/../../../example/docs/index.html');
+    cy.screenshot();
+  });
+
+  it('NotVueComponent should not be rendered as Vue component', () => {
+    cy.get('nav > ul > li a[href="global.html#helloWorld"]').contains('helloWorld');
+    cy.get('nav > ul > li a[href="module-NotVueComponent.html"]').should('not.exist');
+  });
+
+  it('NotVueComponent2 should not be rendered as Vue component', () => {
+    cy.visit('/../../../example/docs/module-NotVueComponent2.html');
+
+    cy.get('nav > ul > li a[href="module-NotVueComponent2.html"]').contains('NotVueComponent2');
+    cy
+      .contains('h3', 'Methods')
+      .should('have.attr', 'class', 'subsection-title')
+      .next()
+      .contains('theMethod')
+      .next('h5')
+      .next('.params')
+      .next('.details')
+      .contains('a[href="js_NotVueComponent2.js.html#line11"]', 'line 11');
   });
 });

--- a/cypress/integration/templates/default.spec.js
+++ b/cypress/integration/templates/default.spec.js
@@ -71,7 +71,7 @@ describe('Template: default', () => {
         name: '<code>counter</code>',
         type: 'Number',
         defaultValue: '-',
-        description: 'Current counter\'s value',
+        description: "Current counter's value",
       },
     ];
 
@@ -237,7 +237,7 @@ describe('Template JS: default', () => {
         name: '<code>counter</code>',
         type: 'Number',
         defaultValue: '-',
-        description: 'Current counter\'s value',
+        description: "Current counter's value",
       },
     ];
 

--- a/cypress/integration/templates/docstrap.spec.js
+++ b/cypress/integration/templates/docstrap.spec.js
@@ -2,7 +2,7 @@
 
 describe('Template: docstrap', () => {
   before(() => {
-    cy.visit('/../../../example/docs-docstrap//module-better-components_BetterCounter.html');
+    cy.visit('/../../../example/docs-docstrap/module-better-components_BetterCounter.html');
     cy.screenshot();
   });
 
@@ -167,7 +167,7 @@ describe('Template: docstrap', () => {
 
 describe('Template JS: docstrap', () => {
   before(() => {
-    cy.visit('/../../../example/docs-docstrap//module-CounterJS.html');
+    cy.visit('/../../../example/docs-docstrap/module-CounterJS.html');
     cy.screenshot();
   });
 
@@ -327,5 +327,35 @@ describe('Template JS: docstrap', () => {
       .contains('a[href="js_CounterJS.js.html#sunlight-1-line-51"]', 'line 51');
 
     cy.contains('created()').should('not.exist');
+  });
+});
+
+
+describe('JS files rendered or not as Vue Component', () => {
+  before(() => {
+    cy.visit('/../../../example/docs-docstrap/index.html');
+    cy.screenshot();
+  });
+
+  it('NotVueComponent should not be rendered as Vue component', () => {
+    cy.get('.nav .dropdown a[href="global.html#helloWorld"]').contains('helloWorld');
+    cy.get('.nav .dropdown a[href="module-NotVueComponent.html"]').should('not.exist');
+  });
+
+  it('NotVueComponent2 should not be rendered as Vue component', () => {
+    cy.visit('/../../../example/docs-docstrap/module-NotVueComponent2.html');
+
+    cy.get('.nav .dropdown a[href="module-NotVueComponent2.html"]').contains('NotVueComponent2');
+
+    cy
+      .contains('h3', 'Methods')
+      .should('have.attr', 'class', 'subsection-title')
+      .next('dl')
+      .find('h4')
+      .contains('theMethod')
+      .parent()
+      .next('dd')
+      .find('.details')
+      .contains('a[href="js_NotVueComponent2.js.html#sunlight-1-line-11"]', 'line 11');
   });
 });

--- a/cypress/integration/templates/minami.spec.js
+++ b/cypress/integration/templates/minami.spec.js
@@ -327,3 +327,30 @@ describe('Template JS: minami', () => {
     cy.contains('created()').should('not.exist');
   });
 });
+
+
+describe('JS files rendered or not as Vue Component', () => {
+  before(() => {
+    cy.visit('/../../../example/docs-minami/index.html');
+    cy.screenshot();
+  });
+
+  it('NotVueComponent should not be rendered as Vue component', () => {
+    cy.get('.nav-item-name a[href="global.html#helloWorld"]').contains('helloWorld');
+    cy.get('.nav-item-name a[href="module-NotVueComponent.html"]').should('not.exist');
+  });
+
+  it('NotVueComponent2 should not be rendered as Vue component', () => {
+    cy.visit('/../../../example/docs-minami/module-NotVueComponent2.html');
+
+    cy.get('.nav-item-name a[href="module-NotVueComponent2.html"]').contains('NotVueComponent2');
+    cy
+      .contains('h3', 'Methods')
+      .should('have.attr', 'class', 'subsection-title')
+      .next('.section-method')
+      .find('h4.name')
+      .contains('theMethod')
+      .next('dl.details')
+      .contains('a[href="js_NotVueComponent2.js.html#line11"]', 'line 11');
+  });
+});

--- a/cypress/integration/templates/tui.spec.js
+++ b/cypress/integration/templates/tui.spec.js
@@ -319,3 +319,30 @@ describe('Template JS: tui', () => {
     cy.contains('created()').should('not.exist');
   });
 });
+
+
+describe('JS files rendered or not as Vue Component', () => {
+  before(() => {
+    cy.visit('/../../../example/docs-tui/index.html');
+    cy.screenshot();
+  });
+
+  it('NotVueComponent should not be rendered as Vue component', () => {
+    cy.get('.lnb-api a[href="global.html#helloWorld"]').contains('helloWorld');
+    cy.get('.lnb-api a[href="module-NotVueComponent.html"]').should('not.exist');
+  });
+
+  it('NotVueComponent2 should not be rendered as Vue component', () => {
+    cy.visit('/../../../example/docs-tui/module-NotVueComponent2.html');
+
+    cy.get('.lnb-api a[href="module-NotVueComponent2.html"]').contains('NotVueComponent2');
+    cy
+      .contains('h3', 'Methods')
+      .should('have.attr', 'class', 'subsection-title')
+      .next('dl')
+      .find('.name')
+      .contains('theMethod')
+      .find('.container-source.members')
+      .contains('a[href="js_NotVueComponent2.js.html#line11"]', 'line 11');
+  });
+});

--- a/example/src/js/NotVueComponent.js
+++ b/example/src/js/NotVueComponent.js
@@ -1,0 +1,15 @@
+import NotVueComponent2 from './NotVueComponent2';
+
+NotVueComponent2.theMethod('123');
+
+/**
+ * @return {Boolean}
+ */
+const helloWorld = () => {
+  console.log('Hello world');
+  return false;
+};
+
+export {
+  helloWorld,
+};

--- a/example/src/js/NotVueComponent2.js
+++ b/example/src/js/NotVueComponent2.js
@@ -1,0 +1,14 @@
+/**
+ * @module NotVueComponent2
+ */
+module.exports = {
+  state: {
+    foo: 'bar',
+  },
+  /**
+   * @param {String} i
+   */
+  theMethod(i) {
+    console.log(i);
+  },
+};

--- a/lib/core/issers.js
+++ b/lib/core/issers.js
@@ -1,0 +1,41 @@
+const path = require('path');
+
+const hasVueTagRE = /\s*\*\s*@vue/;
+
+// Useful because we use `@vue` tag from first doclet of a .js file
+// to determine if this file is a Vue Component.
+/**
+ * @type {Object.<String, Boolean>}
+ */
+const jsComponentsCache = {};
+
+/**
+ * @param {Doclet} doclet
+ */
+function isSingleFileComponent(doclet) {
+  return doclet.meta.filename.endsWith('.vue');
+}
+
+/**
+ * @param {Doclet} doclet
+ */
+function isJSComponent(doclet) {
+  const fullPath = path.join(doclet.meta.path, doclet.meta.filename);
+
+  if (fullPath in jsComponentsCache) {
+    return jsComponentsCache[fullPath];
+  }
+
+  const res = doclet.meta.filename.endsWith('.js') && hasVueTagRE.test(doclet.comment || '');
+
+  if (res) {
+    jsComponentsCache[fullPath] = true;
+  }
+
+  return res;
+}
+
+module.exports = {
+  isSingleFileComponent,
+  isJSComponent,
+};


### PR DESCRIPTION
Close #136  

Since #128, every JavaScripts files were seen as Vue component.
Now, .js files should at least have one `@vue` tag in a comment to be considered as a Vue component.

Recognized as a Vue component:

```js
// Component.js

/**
 * @vue
 */
export default {
  name: 'Component',
}
```
**Not** recognized as a Vue component:

```js
// File.js

export default {
  name: 'File',
}
```
