### PR TITLE
Allow unnamed modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,16 @@ exports.handlers = {
       e.doclet.alias = componentName;
       e.doclet.longname = `module:${componentName}`;
     }
+    // if it's a vue module that wasn't given a name
+    else if (e.doclet.longname.includes(".module:vue")) {
+      // use the default name without the added gunk
+      let newName = e.doclet.longname.replace(".module:vue", "");
+      e.doclet.longname = `module:${newName}`;
+      // fix the name if it's a module. member names aren't affected
+      if (e.doclet.kind === "module") {
+        e.doclet.name = newName;
+      }
+    }
 
     if (
       !/[.~#]/.test(e.doclet.longname) // filter component's properties and member, not the best way but it werks

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ exports.handlers = {
     // if it's a vue module that wasn't given a name
     else if (e.doclet.longname.includes(".module:vue")) {
       // use the default name without the added gunk
-      let newName = e.doclet.longname.replace(".module:vue", "");
+      const newName = e.doclet.longname.replace(".module:vue", "");
       e.doclet.longname = `module:${newName}`;
       // fix the name if it's a module. member names aren't affected
       if (e.doclet.kind === "module") {


### PR DESCRIPTION
Currently, marking a component inside of a .vue file with `/** @module */ without providing a full longname results in a parser-inferred longname ending with ".module:vue" which means the inferred shortname is "vue". All its members then also have ".module:vue" in their longname. 

I fixed that because I don't want to have to explicitly declare module names, especially in deeply nested files. This also allows the documentation to automatically update when modules are refactored and moved.