### PR TITLE
Tweaked config.js to parse config passed into jsdoc-vuejs correctly.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,4 +33,4 @@ test_script:
   - yarn lint
   - yarn test -i
   - yarn codecov
-  - yarn cypress run --config watchForFileChanges=false --record
+  - yarn cypress run --config watchForFileChanges=false

--- a/config.js
+++ b/config.js
@@ -1,11 +1,12 @@
-const config = require('jsdoc/env');
+const env = require('jsdoc/env');
 const getTemplatePath = require('./lib/core/getTemplatePath');
+const config = env.conf || {};
 
 config['jsdoc-vuejs'] = config['jsdoc-vuejs'] || {};
 
 // Detect JSDoc template if not specified
 if (!Object.prototype.hasOwnProperty.call(config['jsdoc-vuejs'], 'template')) {
-  config['jsdoc-vuejs'].template = getTemplatePath(config.opts.template || 'default');
+  config['jsdoc-vuejs'].template = getTemplatePath(env.opts.template || 'default');
 }
 
 module.exports = config;

--- a/config.js
+++ b/config.js
@@ -1,5 +1,6 @@
 const env = require('jsdoc/env');
 const getTemplatePath = require('./lib/core/getTemplatePath');
+
 const config = env.conf || {};
 
 config['jsdoc-vuejs'] = config['jsdoc-vuejs'] || {};


### PR DESCRIPTION
config.js was checking for the `jsdoc-vuejs` config against `jsdoc/env`, but configs are stored under `jsdoc/env`'s `conf` property. So the `jsdoc-vuejs` `template` property was never picked up, and always fell back to the default jsdoc template.