### PR TITLE
fix: JSDoc 3.6+ and Markdown plugin support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,13 @@
 environment:
   matrix:
     - nodejs_version: "8"
+      JSDOC_VERSION: <3.6
+
     - nodejs_version: ""
+      JSDOC_VERSION: >=3.6
+
+    - nodejs_version: ""
+      JSDOC_VERSION: <3.6
 
 cache:
   - node_modules
@@ -14,9 +20,11 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - npm install -g yarn
   - yarn install --frozen-lockfile
+  - yarn add --save-dev jsdoc@$env:JSDOC_VERSION
   - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER) { yarn cypress install }
   - cd example
   - yarn install --frozen-lockfile
+  - yarn add --save-dev jsdoc@$env:JSDOC_VERSION
   - cd ..
 
 build: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,13 +1,7 @@
 environment:
   matrix:
     - nodejs_version: "8"
-      JSDOC_PKG: jsdoc@<3.6
-
     - nodejs_version: ""
-      JSDOC_PKG: jsdoc@>=3.6
-
-    - nodejs_version: ""
-      JSDOC_PKG: jsdoc@<3.6
 
 cache:
   - node_modules
@@ -20,11 +14,9 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - npm install -g yarn
   - yarn install --frozen-lockfile
-  - yarn add --save-dev $env:JSDOC_PKG
   - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER) { yarn cypress install }
   - cd example
   - yarn install --frozen-lockfile
-  - yarn add --save-dev $env:JSDOC_PKG
   - cd ..
 
 build: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,13 +1,13 @@
 environment:
   matrix:
     - nodejs_version: "8"
-      JSDOC_VERSION: <3.6
+      JSDOC_PKG: jsdoc@<3.6
 
     - nodejs_version: ""
-      JSDOC_VERSION: >=3.6
+      JSDOC_PKG: jsdoc@>=3.6
 
     - nodejs_version: ""
-      JSDOC_VERSION: <3.6
+      JSDOC_PKG: jsdoc@<3.6
 
 cache:
   - node_modules
@@ -20,11 +20,11 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - npm install -g yarn
   - yarn install --frozen-lockfile
-  - yarn add --save-dev jsdoc@$env:JSDOC_VERSION
+  - yarn add --save-dev $env:JSDOC_PKG
   - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER) { yarn cypress install }
   - cd example
   - yarn install --frozen-lockfile
-  - yarn add --save-dev jsdoc@$env:JSDOC_VERSION
+  - yarn add --save-dev $env:JSDOC_PKG
   - cd ..
 
 build: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,8 @@ before_install:
 
 install:
   - yarn install --frozen-lockfile
-  - echo $JSDOC_PKG
-  - echo ${JSDOC_PKG}
-  - yarn add --save-dev ${JSDOC_PKG}
-  - (cd example; yarn install --frozen-lockfile; yarn add --save-dev ${JSDOC_PKG})
+  - bash -c "yarn add --save-dev ${JSDOC_PKG}"
+  - (cd example; yarn install --frozen-lockfile; bash -c "yarn add --save-dev ${JSDOC_PKG}")
   - if [[ "${TRAVIS_EVENT_TYPE}" = pull_request ]]; then yarn cypress install; fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ node_js:
   - "node"
 
 env:
-  - JSDOC_VERSION="<3.6"
-  - JSDOC_VERSION=">=3.6"
+  - JSDOC_PKG="jsdoc@<3.6"
+  - JSDOC_PKG="jsdoc@>=3.6"
 
 matrix:
   exclude:
     - node_js: "node"
-      env: JSDOC_VERSION="<3.6"
+      env: JSDOC_PKG="jsdoc@<3.6"
 
 branches:
   except:
@@ -31,9 +31,10 @@ before_install:
 
 install:
   - yarn install --frozen-lockfile
-  - echo $JSDOC_VERSION
-  - yarn add --save-dev jsdoc@$JSDOC_VERSION
-  - (cd example; yarn install --frozen-lockfile; yarn add --save-dev jsdoc@$JSDOC_VERSION)
+  - echo $JSDOC_PKG
+  - echo ${JSDOC_PKG}
+  - yarn add --save-dev ${JSDOC_PKG}
+  - (cd example; yarn install --frozen-lockfile; yarn add --save-dev ${JSDOC_PKG})
   - if [[ "${TRAVIS_EVENT_TYPE}" = pull_request ]]; then yarn cypress install; fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,15 @@ node_js:
   - "8"
   - "node"
 
+env:
+  - JSDOC_VERSION="<3.6"
+  - JSDOC_VERSION=">=3.6"
+
+matrix:
+  exclude:
+    - node_js: "node"
+      env: JSDOC_VERSION="<3.6"
+
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/
@@ -22,7 +31,9 @@ before_install:
 
 install:
   - yarn install --frozen-lockfile
-  - cd example && yarn install --frozen-lockfile && cd ..
+  - echo $JSDOC_VERSION
+  - yarn add --save-dev jsdoc@$JSDOC_VERSION
+  - (cd example; yarn install --frozen-lockfile; yarn add --save-dev jsdoc@$JSDOC_VERSION)
   - if [[ "${TRAVIS_EVENT_TYPE}" = pull_request ]]; then yarn cypress install; fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,6 @@ node_js:
   - "8"
   - "node"
 
-env:
-  - JSDOC_PKG="jsdoc@<3.6"
-  - JSDOC_PKG="jsdoc@>=3.6"
-
-matrix:
-  exclude:
-    - node_js: "node"
-      env: JSDOC_PKG="jsdoc@<3.6"
-
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/
@@ -31,8 +22,7 @@ before_install:
 
 install:
   - yarn install --frozen-lockfile
-  - sh -c "yarn add --save-dev ${JSDOC_PKG}"
-  - (cd example; yarn install --frozen-lockfile; sh -c "yarn add --save-dev ${JSDOC_PKG}")
+  - (cd example; yarn install --frozen-lockfile)
   - if [[ "${TRAVIS_EVENT_TYPE}" = pull_request ]]; then yarn cypress install; fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ before_install:
 
 install:
   - yarn install --frozen-lockfile
-  - bash -c "yarn add --save-dev ${JSDOC_PKG}"
-  - (cd example; yarn install --frozen-lockfile; bash -c "yarn add --save-dev ${JSDOC_PKG}")
+  - sh -c "yarn add --save-dev ${JSDOC_PKG}"
+  - (cd example; yarn install --frozen-lockfile; sh -c "yarn add --save-dev ${JSDOC_PKG}")
   - if [[ "${TRAVIS_EVENT_TYPE}" = pull_request ]]; then yarn cypress install; fi
 
 before_script:

--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "ink-docstrap": "^1.3.2",
-    "jsdoc": "^3.5.5",
+    "jsdoc": "^3.6.3",
     "minami": "^1.2.3",
     "tui-jsdoc-template": "^1.2.2",
     "vuex": "^3.0.1"

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@babel/parser@^7.4.4":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.5.5.tgz#02f077ac8817d3df4a832ef59de67565e71cca4b"
+  integrity sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -9,32 +14,34 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+  dependencies:
+    sprintf-js "~1.0.2"
+
 array-uniq@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
-babylon@7.0.0-beta.19:
-  version "7.0.0-beta.19"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.19.tgz#e928c7e807e970e0536b078ab3e0c48f9e052503"
-  integrity sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==
-
-bluebird@~3.5.0:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
-  integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
+bluebird@^3.5.4:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
+  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
 
 boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-catharsis@~0.8.9:
-  version "0.8.9"
-  resolved "https://registry.yarnpkg.com/catharsis/-/catharsis-0.8.9.tgz#98cc890ca652dd2ef0e70b37925310ff9e90fc8b"
-  integrity sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=
+catharsis@^0.8.11:
+  version "0.8.11"
+  resolved "https://registry.yarnpkg.com/catharsis/-/catharsis-0.8.11.tgz#d0eb3d2b82b7da7a3ce2efb1a7b00becc6643468"
+  integrity sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==
   dependencies:
-    underscore-contrib "~0.3.0"
+    lodash "^4.17.14"
 
 chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.1"
@@ -145,10 +152,15 @@ entities@^1.1.1, entities@~1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
   integrity sha1-blwtClYhtdra7O+AuQ7ftc13cvA=
 
-escape-string-regexp@^1.0.5, escape-string-regexp@~1.0.5:
+escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 graceful-fs@^4.1.9:
   version "4.1.11"
@@ -190,37 +202,46 @@ isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
-js2xmlparser@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/js2xmlparser/-/js2xmlparser-3.0.0.tgz#3fb60eaa089c5440f9319f51760ccd07e2499733"
-  integrity sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=
+js2xmlparser@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js2xmlparser/-/js2xmlparser-4.0.0.tgz#ae14cc711b2892083eed6e219fbc993d858bc3a5"
+  integrity sha512-WuNgdZOXVmBk5kUPMcTcVUpbGRzLfNkv7+7APq7WiDihpXVKrgxo6wwRpRl9OQeEBgKCVk9mR7RbzrnNWC8oBw==
   dependencies:
-    xmlcreate "^1.0.1"
+    xmlcreate "^2.0.0"
 
-jsdoc@^3.5.5:
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-3.5.5.tgz#484521b126e81904d632ff83ec9aaa096708fa4d"
-  integrity sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==
+jsdoc@^3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-3.6.3.tgz#dccea97d0e62d63d306b8b3ed1527173b5e2190d"
+  integrity sha512-Yf1ZKA3r9nvtMWHO1kEuMZTlHOF8uoQ0vyo5eH7SQy5YeIiHM+B0DgKnn+X6y6KDYZcF7G2SPkKF+JORCXWE/A==
   dependencies:
-    babylon "7.0.0-beta.19"
-    bluebird "~3.5.0"
-    catharsis "~0.8.9"
-    escape-string-regexp "~1.0.5"
-    js2xmlparser "~3.0.0"
-    klaw "~2.0.0"
-    marked "~0.3.6"
-    mkdirp "~0.5.1"
-    requizzle "~0.2.1"
-    strip-json-comments "~2.0.1"
+    "@babel/parser" "^7.4.4"
+    bluebird "^3.5.4"
+    catharsis "^0.8.11"
+    escape-string-regexp "^2.0.0"
+    js2xmlparser "^4.0.0"
+    klaw "^3.0.0"
+    markdown-it "^8.4.2"
+    markdown-it-anchor "^5.0.2"
+    marked "^0.7.0"
+    mkdirp "^0.5.1"
+    requizzle "^0.2.3"
+    strip-json-comments "^3.0.1"
     taffydb "2.6.2"
-    underscore "~1.8.3"
+    underscore "~1.9.1"
 
-klaw@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/klaw/-/klaw-2.0.0.tgz#59c128e0dc5ce410201151194eeb9cbf858650f6"
-  integrity sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=
+klaw@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-3.0.0.tgz#b11bec9cf2492f06756d6e809ab73a2910259146"
+  integrity sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==
   dependencies:
     graceful-fs "^4.1.9"
+
+linkify-it@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
+  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
+  dependencies:
+    uc.micro "^1.0.1"
 
 lodash.assignin@^4.0.9:
   version "4.2.0"
@@ -307,10 +328,36 @@ lodash.some@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
   integrity sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=
 
-marked@~0.3.6:
-  version "0.3.12"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.12.tgz#7cf25ff2252632f3fe2406bde258e94eee927519"
-  integrity sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==
+lodash@^4.17.14:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+markdown-it-anchor@^5.0.2:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-5.2.4.tgz#d39306fe4c199705b4479d3036842cf34dcba24f"
+  integrity sha512-n8zCGjxA3T+Mx1pG8HEgbJbkB8JFUuRkeTZQuIM8iPY6oQ8sWOPRZJDFC9a/pNg2QkHEjjGkhBEl/RSyzaDZ3A==
+
+markdown-it@^8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.2.tgz#386f98998dc15a37722aa7722084f4020bdd9b54"
+  integrity sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==
+  dependencies:
+    argparse "^1.0.7"
+    entities "~1.1.1"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
+  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 minami@^1.2.3:
   version "1.2.3"
@@ -322,7 +369,7 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-mkdirp@~0.5.1:
+mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -373,12 +420,12 @@ readable-stream@^2.0.2:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-requizzle@~0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/requizzle/-/requizzle-0.2.1.tgz#6943c3530c4d9a7e46f1cddd51c158fc670cdbde"
-  integrity sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=
+requizzle@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/requizzle/-/requizzle-0.2.3.tgz#4675c90aacafb2c036bd39ba2daa4a1cb777fded"
+  integrity sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==
   dependencies:
-    underscore "~1.6.0"
+    lodash "^4.17.14"
 
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -406,6 +453,11 @@ source-map@^0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
 srcset@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/srcset/-/srcset-1.0.0.tgz#a5669de12b42f3b1d5e83ed03c71046fc48f41ef"
@@ -421,10 +473,10 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+strip-json-comments@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
+  integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
 
 supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.4.0"
@@ -445,22 +497,15 @@ tui-jsdoc-template@^1.2.2:
   dependencies:
     cheerio "^0.22.0"
 
-underscore-contrib@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/underscore-contrib/-/underscore-contrib-0.3.0.tgz#665b66c24783f8fa2b18c9f8cbb0e2c7d48c26c7"
-  integrity sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=
-  dependencies:
-    underscore "1.6.0"
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
-underscore@1.6.0, underscore@~1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
-  integrity sha1-izixDKze9jM3uLJOT/htRa6lKag=
-
-underscore@~1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
-  integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
+underscore@~1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
+  integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -472,10 +517,10 @@ vuex@^3.0.1:
   resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.0.1.tgz#e761352ebe0af537d4bb755a9b9dc4be3df7efd2"
   integrity sha512-wLoqz0B7DSZtgbWL1ShIBBCjv22GV5U+vcBFox658g6V0s4wZV9P4YjCNyoHSyIBpj1f29JBoNQIqD82cR4O3w==
 
-xmlcreate@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/xmlcreate/-/xmlcreate-1.0.2.tgz#fa6bf762a60a413fb3dd8f4b03c5b269238d308f"
-  integrity sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=
+xmlcreate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/xmlcreate/-/xmlcreate-2.0.1.tgz#2ec38bd7b708d213fd1a90e2431c4af9c09f6a52"
+  integrity sha512-MjGsXhKG8YjTKrDCXseFo3ClbMGvUD4en29H2Cev1dv4P/chlpw6KdYmlCWDkhosBVKRDjM836+3e3pm1cBNJA==
 
 xtend@^4.0.0:
   version "4.0.1"

--- a/lib/templates/default.ejs
+++ b/lib/templates/default.ejs
@@ -12,17 +12,13 @@
         <th>Description</th>
     </tr>
     </thead>
-    <tbody>
-    <% props.forEach(function(prop) { %>
-    <tr>
+    <tbody><% props.forEach(function(prop) { %><tr>
         <td><code><%- prop.name %></code></td>
         <td><%- renderType(prop.type) %></td>
         <td><%- typeof prop.defaultvalue === 'undefined' ? '-' : `<code>${prop.defaultvalue}</code>` %></td>
         <td><%- prop.optional ? 'No' : '<b>Yes</b>' %></td>
         <td><%- typeof prop.description === 'undefined' ? '-' : prop.description %></td>
-    </tr>
-    <% }) %>
-    </tbody>
+    </tr><% }) %></tbody>
 </table>
 <% } %>
 
@@ -37,16 +33,12 @@
         <th>Description</th>
     </tr>
     </thead>
-    <tbody>
-    <% data.forEach(function(d) { %>
-    <tr>
+    <tbody><% data.forEach(function(d) { %><tr>
         <td><code><%- d.name %></code></td>
         <td><%- renderType(d.type) %></td>
         <td><%- typeof d.defaultvalue === 'undefined' ? '-' : `<code>${d.defaultvalue}</code>` %></td>
         <td><%- typeof d.description === 'undefined' ? '-' : d.description %></td>
-    </tr>
-    <% }) %>
-    </tbody>
+    </tr><% }) %></tbody>
 </table>
 <% } %>
 
@@ -60,15 +52,11 @@
         <th>Description</th>
     </tr>
     </thead>
-    <tbody>
-    <% computed.forEach(function(c) { %>
-    <tr>
+    <tbody><% computed.forEach(function(c) { %><tr>
         <td><code><%- c.name %></code></td>
         <td><%- renderType(c.type) %></td>
         <td><%- typeof c.description === 'undefined' ? '-' : c.description %></td>
-    </tr>
-    <% }) %>
-    </tbody>
+    </tr><% }) %></tbody>
 </table>
 <% } %>
 
@@ -83,15 +71,11 @@
         <th>Description</th>
     </tr>
     </thead>
-    <tbody>
-    <% event.forEach(function(c) { %>
-    <tr>
+    <tbody><% event.forEach(function(c) { %><tr>
         <td><code><%- c.name %></code></td>
         <td><%- renderType(c.type) %></td>
         <td><%- typeof c.description === 'undefined' ? '-' : c.description %></td>
-    </tr>
-    <% }) %>
-    </tbody>
+    </tr><% }) %></tbody>
 </table>
 <% } %>
 

--- a/lib/templates/docstrap.ejs
+++ b/lib/templates/docstrap.ejs
@@ -12,17 +12,13 @@
         <th>Description</th>
     </tr>
     </thead>
-    <tbody>
-    <% props.forEach(function(prop) { %>
-    <tr>
+    <tbody><% props.forEach(function(prop) { %><tr>
         <td><code><%- prop.name %></code></td>
         <td><%- renderType(prop.type) %></td>
         <td><%- typeof prop.defaultvalue === 'undefined' ? '-' : `<code>${prop.defaultvalue}</code>` %></td>
         <td><%- prop.optional ? 'No' : '<b>Yes</b>' %></td>
         <td><%- typeof prop.description === 'undefined' ? '-' : prop.description %></td>
-    </tr>
-    <% }) %>
-    </tbody>
+    </tr><% }) %></tbody>
 </table>
 <% } %>
 
@@ -37,16 +33,12 @@
         <th>Description</th>
     </tr>
     </thead>
-    <tbody>
-    <% data.forEach(function(d) { %>
-    <tr>
+    <tbody><% data.forEach(function(d) { %><tr>
         <td><code><%- d.name %></code></td>
         <td><%- renderType(d.type) %></td>
         <td><%- typeof d.defaultvalue === 'undefined' ? '-' : `<code>${d.defaultvalue}</code>` %></td>
         <td><%- typeof d.description === 'undefined' ? '-' : d.description %></td>
-    </tr>
-    <% }) %>
-    </tbody>
+    </tr><% }) %></tbody>
 </table>
 <% } %>
 
@@ -60,15 +52,11 @@
         <th>Description</th>
     </tr>
     </thead>
-    <tbody>
-    <% computed.forEach(function(c) { %>
-    <tr>
+    <tbody><% computed.forEach(function(c) { %><tr>
         <td><code><%- c.name %></code></td>
         <td><%- renderType(c.type) %></td>
         <td><%- typeof c.description === 'undefined' ? '-' : c.description %></td>
-    </tr>
-    <% }) %>
-    </tbody>
+    </tr><% }) %></tbody>
 </table>
 <% } %>
 
@@ -82,15 +70,11 @@
         <th>Description</th>
     </tr>
     </thead>
-    <tbody>
-    <% event.forEach(function(c) { %>
-    <tr>
+    <tbody><% event.forEach(function(c) { %><tr>
         <td><code><%- c.name %></code></td>
         <td><%- renderType(c.type) %></td>
         <td><%- typeof c.description === 'undefined' ? '-' : c.description %></td>
-    </tr>
-    <% }) %>
-    </tbody>
+    </tr><% }) %></tbody>
 </table>
 <% } %>
 

--- a/lib/templates/minami.ejs
+++ b/lib/templates/minami.ejs
@@ -12,17 +12,13 @@
         <th>Description</th>
     </tr>
     </thead>
-    <tbody>
-    <% props.forEach(function(prop) { %>
-    <tr>
+    <tbody><% props.forEach(function(prop) { %><tr>
         <td class="name"><code><%- prop.name %></code></td>
         <td><code><%- renderType(prop.type) %></code></td>
         <td><%- typeof prop.defaultvalue === 'undefined' ? '-' : `<code>${prop.defaultvalue}</code>` %></td>
         <td><%- prop.optional ? 'No' : '<b>Yes</b>' %></td>
         <td><%- typeof prop.description === 'undefined' ? '-' : prop.description %></td>
-    </tr>
-    <% }) %>
-    </tbody>
+    </tr><% }) %></tbody>
 </table>
 <% } %>
 
@@ -37,16 +33,12 @@
         <th>Description</th>
     </tr>
     </thead>
-    <tbody>
-    <% data.forEach(function(d) { %>
-    <tr>
+    <tbody><% data.forEach(function(d) { %><tr>
         <td class="name"><code><%- d.name %></code></td>
         <td><code><%- renderType(d.type) %></code></td>
         <td><%- typeof d.defaultvalue === 'undefined' ? '-' : `<code>${d.defaultvalue}</code>` %></td>
         <td><%- typeof d.description === 'undefined' ? '-' : d.description %></td>
-    </tr>
-    <% }) %>
-    </tbody>
+    </tr><% }) %></tbody>
 </table>
 <% } %>
 
@@ -60,15 +52,11 @@
         <th>Description</th>
     </tr>
     </thead>
-    <tbody>
-    <% computed.forEach(function(c) { %>
-    <tr>
+    <tbody><% computed.forEach(function(c) { %><tr>
         <td class="name"><code><%- c.name %></code></td>
         <td><code><%- renderType(c.type) %></code></td>
         <td><%- typeof c.description === 'undefined' ? '-' : c.description %></td>
-    </tr>
-    <% }) %>
-    </tbody>
+    </tr><% }) %></tbody>
 </table>
 <% } %>
 
@@ -82,15 +70,11 @@
         <th>Description</th>
     </tr>
     </thead>
-    <tbody>
-    <% event.forEach(function(c) { %>
-    <tr>
+    <tbody><% event.forEach(function(c) { %><tr>
         <td><code><%- c.name %></code></td>
         <td><%- renderType(c.type) %></td>
         <td><%- typeof c.description === 'undefined' ? '-' : c.description %></td>
-    </tr>
-    <% }) %>
-    </tbody>
+    </tr><% }) %></tbody>
 </table>
 <% } %>
 

--- a/lib/templates/tui.ejs
+++ b/lib/templates/tui.ejs
@@ -26,17 +26,13 @@
             <th class="last">Description</th>
         </tr>
         </thead>
-        <tbody>
-        <% props.forEach(function(prop) { %>
-        <tr>
+        <tbody><% props.forEach(function(prop) { %><tr>
             <td class="name"><code><%- prop.name %></code></td>
             <td class="type"><span class="param-type"><%- renderType(prop.type) %></span></td>
             <td class="description"><%- typeof prop.defaultvalue === 'undefined' ? '-' : `<code>${prop.defaultvalue}</code>` %></td>
             <td class="description"><%- prop.optional ? 'No' : '<b>Yes</b>' %></td>
             <td class="description last"><%- typeof prop.description === 'undefined' ? '-' : prop.description %></td>
-        </tr>
-        <% }) %>
-        </tbody>
+        </tr><% }) %></tbody>
     </table>
 </div>
 <% } %>
@@ -53,16 +49,12 @@
             <th class="last">Description</th>
         </tr>
         </thead>
-        <tbody>
-        <% data.forEach(function(d) { %>
-        <tr>
+        <tbody><% data.forEach(function(d) { %><tr>
             <td class="name"><code><%- d.name %></code></td>
             <td class="type"><span class="param-type"><%- renderType(d.type) %></span></td>
             <td class="description"><%- typeof d.defaultvalue === 'undefined' ? '-' : `<code>${d.defaultvalue}</code>` %></td>
             <td class="description last"><%- typeof d.description === 'undefined' ? '-' : d.description %></td>
-        </tr>
-        <% }) %>
-        </tbody>
+        </tr><% }) %></tbody>
     </table>
 </div>
 <% } %>
@@ -78,15 +70,11 @@
             <th class="last">Description</th>
         </tr>
         </thead>
-        <tbody>
-        <% computed.forEach(function(c) { %>
-        <tr>
+        <tbody><% computed.forEach(function(c) { %><tr>
             <td class="name"><code><%- c.name %></code></td>
             <td class="type"><span class="param-type"><%- renderType(c.type) %></span></td>
             <td class="description last"><%- typeof c.description === 'undefined' ? '-' : c.description %></td>
-        </tr>
-        <% }) %>
-        </tbody>
+        </tr><% }) %></tbody>
     </table>
 </div>
 <% } %>
@@ -102,15 +90,11 @@
             <th class="last">Description</th>
         </tr>
         </thead>
-        <tbody>
-        <% event.forEach(function(c) { %>
-        <tr>
+        <tbody><% event.forEach(function(c) { %><tr>
             <td class="name"><code><%- c.name %></code></td>
             <td class="type"><span class="param-type"><%- renderType(c.type) %></span></td>
             <td class="description last"><%- typeof c.description === 'undefined' ? '-' : c.description %></td>
-        </tr>
-        <% }) %>
-        </tbody>
+        </tr><% }) %></tbody>
     </table>
 </div>
 <% } %>


### PR DESCRIPTION
Render is actually broken in JSDoc 3.6+:
![Capture d’écran de 2019-07-31 22-12-13](https://user-images.githubusercontent.com/2103975/62244727-56187380-b3e0-11e9-81f1-bc0aec034cf7.png)
